### PR TITLE
fix: FORMAT is a string

### DIFF
--- a/_extensions/lua-env/_extension.yml
+++ b/_extensions/lua-env/_extension.yml
@@ -1,6 +1,6 @@
 title: lua-env
 author: Mickaël Canouil
-version: 1.0.1
+version: 1.0.2
 quarto-required: ">=1.4.459"
 contributes:
   shortcodes:

--- a/_extensions/lua-env/lua-env-filter.lua
+++ b/_extensions/lua-env/lua-env-filter.lua
@@ -75,7 +75,7 @@ function Meta(meta)
     ["quarto"] = get_values(quarto),
     ["pandoc"] = {
       ["PANDOC_STATE"] = get_values(PANDOC_STATE),
-      ["FORMAT"] = get_values(FORMAT),
+      ["FORMAT"] = tostring(FORMAT),
       ["PANDOC_READER_OPTIONS"] = get_values(PANDOC_READER_OPTIONS),
       ["PANDOC_WRITER_OPTIONS"] = get_values(PANDOC_WRITER_OPTIONS),
       ["PANDOC_VERSION"] = tostring(PANDOC_VERSION),

--- a/example.qmd
+++ b/example.qmd
@@ -8,11 +8,18 @@ filters:
 
 ### Quarto
 
+::: {.columns}
+
+:::: {.column}
+
 ```markdown
 {{{< lua-env quarto.doc.input_file >}}}
 ```
 
 {{< lua-env quarto.doc.input_file >}}
+
+::::
+:::: {.column}
 
 ```markdown
 {{{< meta lua-env.quarto.doc.input_file >}}}
@@ -20,7 +27,13 @@ filters:
 
 {{< meta lua-env.quarto.doc.input_file >}}
 
+::::
+:::
+
 ### Pandoc
+
+::: {.columns}
+:::: {.column}
 
 ```markdown
 {{{< lua-env pandoc.PANDOC_VERSION >}}}
@@ -28,8 +41,35 @@ filters:
 
 {{< lua-env pandoc.PANDOC_VERSION >}}
 
+::::
+:::: {.column}
+
 ```markdown
 {{{< meta lua-env.pandoc.PANDOC_VERSION >}}}
 ```
 
 {{< meta lua-env.pandoc.PANDOC_VERSION >}}
+
+::::
+:::
+
+::: {.columns}
+:::: {.column}
+
+```markdown
+{{{< lua-env pandoc.FORMAT >}}}
+```
+
+{{< lua-env pandoc.FORMAT >}}
+
+::::
+:::: {.column}
+
+```markdown
+{{{< meta lua-env.pandoc.FORMAT >}}}
+```
+
+{{< meta lua-env.pandoc.FORMAT >}}
+
+::::
+:::


### PR DESCRIPTION
This pull request updates the lua-env extension to version 1.0.2. The `FORMAT` variable is now converted to a string in the `lua-env-filter.lua` file.