### PR TITLE
feat: add JSON export functionality for lua-env metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pdf
 *_files/
 /.luarc.json
+lua-env.json

--- a/README.md
+++ b/README.md
@@ -45,6 +45,34 @@ lua-env:
 
 See [Pandoc LUA API - Global Variables](https://pandoc.org/lua-filters.html#global-variables) for more information about Pandoc global variables.
 
+## JSON Export
+
+You can export the `lua-env` metadata to a JSON file by configuring the `json` option.
+
+By default, no JSON file is written (`json: false`).
+
+To enable JSON export with the default filename:
+
+```yaml
+filters:
+  - lua-env
+extensions:
+  lua-env:
+    json: true  # Exports to "lua-env.json"
+```
+
+To specify a custom file path:
+
+```yaml
+filters:
+  - lua-env
+extensions:
+  lua-env:
+    json: "custom-path.json"  # Exports to "custom-path.json"
+```
+
+The JSON file will contain all the LUA environment metadata collected during document rendering.
+
 ## Example
 
 Here is the source code for a minimal example: [example.qmd](example.qmd).

--- a/_extensions/lua-env/lua-env-filter.lua
+++ b/_extensions/lua-env/lua-env-filter.lua
@@ -22,7 +22,68 @@
 # SOFTWARE.
 ]]
 
-local function is_empty(obj)
+--- @type string|nil The JSON file path to export metadata to
+local json_file = nil
+
+--- Check if a string is empty or nil
+--- @param s string|nil The string to check
+--- @return boolean true if the string is nil or empty
+local function is_empty(s)
+  return s == nil or s == ''
+end
+
+--- Extract metadata value from document meta using nested structure
+--- @param meta table The document metadata table
+--- @param key string The metadata key to retrieve
+--- @return string|nil The metadata value as a string, or nil if not found
+local function get_metadata_value(meta, key)
+  -- Check for the nested structure: extensions.lua-env.key
+  if meta['extensions'] and meta['extensions']['lua-env'] and meta['extensions']['lua-env'][key] then
+    return pandoc.utils.stringify(meta['extensions']['lua-env'][key])
+  end
+
+  return nil
+end
+
+--- Export metadata to JSON file
+--- @param metadata table The metadata to export
+--- @param filepath string The file path to write to
+local function export_to_json(metadata, filepath)
+  local json_content = quarto.json.encode(metadata)
+  local file, err = io.open(filepath, "w")
+  if file then
+    file:write(json_content)
+    file:close()
+    quarto.log.output("Exported lua-env metadata to: " .. filepath)
+  else
+    quarto.log.error("Failed to write JSON file: " .. (err or "unknown error"))
+  end
+end
+
+--- Get configuration from metadata
+--- @param meta table The document metadata table
+--- @return table The metadata table
+local function get_configuration(meta)
+  local meta_json = get_metadata_value(meta, 'json')
+
+  -- Set JSON file path
+  if not is_empty(meta_json) then
+    if meta_json == "true" then
+      json_file = "lua-env.json"
+    elseif meta_json == "false" then
+      json_file = nil
+    else
+      json_file = meta_json --[[@as string]]
+    end
+  end
+
+  return meta
+end
+
+--- Check if an object (including tables and lists) is empty or nil
+--- @param obj any The object to check
+--- @return boolean true if the object is nil, empty string, or empty table/list
+local function is_object_empty(obj)
   local function length(x)
     local count = 0
     if x ~= nil then
@@ -39,23 +100,32 @@ local function is_empty(obj)
   end
 end
 
+--- Check if an object is a simple type (string, number, or boolean)
+--- @param obj any The object to check
+--- @return boolean true if the object is a string, number, or boolean
 local function is_type_simple(obj)
   return pandoc.utils.type(obj) == "string" or pandoc.utils.type(obj) == "number" or pandoc.utils.type(obj) == "boolean"
 end
 
+--- Check if an object is a function or userdata
+--- @param obj any The object to check
+--- @return boolean true if the object is a function or userdata
 local function is_function_userdata(obj)
   return pandoc.utils.type(obj) == "function" or pandoc.utils.type(obj) == "userdata"
 end
 
+--- Recursively extract values from an object, filtering out empty, function, and userdata values
+--- @param obj any The object to extract values from
+--- @return table A table containing the extracted values
 local function get_values(obj)
   local values_array = {}
-  if not is_empty(obj) then
+  if not is_object_empty(obj) then
     if not is_type_simple(obj) and not is_function_userdata(obj) then
       for k, v in pairs(obj) do
-        if not is_empty(v) then
+        if not is_object_empty(v) then
           if not is_type_simple(v) and not is_function_userdata(v) then
             local values_array_temp = get_values(v)
-            if not is_empty(values_array_temp) then
+            if not is_object_empty(values_array_temp) then
               values_array[k] = values_array_temp
             end
           elseif pandoc.utils.type(v) ~= "table" and not is_function_userdata(v) then
@@ -70,7 +140,10 @@ local function get_values(obj)
   return values_array
 end
 
-function Meta(meta)
+--- Populate lua-env metadata
+--- @param meta table The document metadata table
+--- @return table The metadata table with lua-env populated
+function populate_lua_env(meta)
   meta["lua-env"] = {
     ["quarto"] = get_values(quarto),
     ["pandoc"] = {
@@ -83,6 +156,21 @@ function Meta(meta)
       ["PANDOC_SCRIPT_FILE"] = get_values(PANDOC_SCRIPT_FILE)
     }
   }
+  
+  -- Export to JSON if configured
+  if json_file then
+    export_to_json(meta["lua-env"], json_file)
+  end
+  
   -- quarto.log.output(meta["lua-env"])
   return meta
 end
+
+--- Pandoc filter configuration
+--- Defines the order of filter execution:
+--- 1. Get configuration from metadata
+--- 2. Populate lua-env metadata and export to JSON if configured
+return {
+  { Meta = get_configuration },
+  { Meta = populate_lua_env }
+}

--- a/example.qmd
+++ b/example.qmd
@@ -3,15 +3,18 @@ title: "lua-env Example"
 format: html
 filters:
   - lua-env
+extensions:
+  lua-env:
+    json: true  # Export metadata to lua-env.json
 ---
 
 ## Shortcodes
 
 ### Quarto
 
-::: {.columns}
+:::: {layout-ncol="2"}
 
-:::: {.column}
+:::: {}
 
 ```markdown
 {{{< lua-env quarto.doc.input_file >}}}
@@ -19,8 +22,9 @@ filters:
 
 {{< lua-env quarto.doc.input_file >}}
 
-::::
-:::: {.column}
+:::
+
+:::: {}
 
 ```markdown
 {{{< meta lua-env.quarto.doc.input_file >}}}
@@ -28,13 +32,13 @@ filters:
 
 {{< meta lua-env.quarto.doc.input_file >}}
 
-::::
+:::
 :::
 
 ### Pandoc
 
-::: {.columns}
-:::: {.column}
+:::: {layout-ncol="2"}
+:::: {}
 
 ```markdown
 {{{< lua-env pandoc.PANDOC_VERSION >}}}
@@ -42,8 +46,8 @@ filters:
 
 {{< lua-env pandoc.PANDOC_VERSION >}}
 
-::::
-:::: {.column}
+:::
+:::: {}
 
 ```markdown
 {{{< meta lua-env.pandoc.PANDOC_VERSION >}}}
@@ -51,11 +55,11 @@ filters:
 
 {{< meta lua-env.pandoc.PANDOC_VERSION >}}
 
-::::
+:::
 :::
 
-::: {.columns}
-:::: {.column}
+:::: {layout-ncol="2"}
+:::: {}
 
 ```markdown
 {{{< lua-env pandoc.FORMAT >}}}
@@ -63,8 +67,8 @@ filters:
 
 {{< lua-env pandoc.FORMAT >}}
 
-::::
-:::: {.column}
+:::
+:::: {}
 
 ```markdown
 {{{< meta lua-env.pandoc.FORMAT >}}}
@@ -72,5 +76,29 @@ filters:
 
 {{< meta lua-env.pandoc.FORMAT >}}
 
-::::
 :::
+:::
+
+## JSON Export
+
+This document is configured to export the `lua-env` metadata to a JSON file.
+
+By default, no JSON file is written (`json: false`). To enable JSON export, set `json: true` or provide a custom file path.
+
+The YAML header includes:
+
+```yaml
+extensions:
+  lua-env:
+    json: true  # Export metadata to lua-env.json
+```
+
+This will create a file named `lua-env.json` in the same directory as this document, containing all the LUA environment metadata collected during rendering.
+
+You can also specify a custom file path:
+
+```yaml
+extensions:
+  lua-env:
+    json: "custom-output.json"
+```


### PR DESCRIPTION
Introduce the ability to export lua-env metadata to a JSON file, enhancing the usability of the extension. Update the README to include configuration examples for enabling JSON export and specify custom file paths.