### PR TITLE
chore: add $schema version URI to _schema.yml

### DIFF
--- a/_extensions/lua-env/_schema.yml
+++ b/_extensions/lua-env/_schema.yml
@@ -6,6 +6,9 @@
 #   extensions:
 #     lua-env:
 #       json: true
+
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
 options:
   json:
     type: [boolean, string]


### PR DESCRIPTION
## Summary

- Add `$schema` version URI to `_schema.yml` for IDE tooling and validation alignment.

References [quarto-wizard#272](https://github.com/mcanouil/quarto-wizard/pull/272).