### PR TITLE
fix: declare the filter entry point in the extension manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Register the filter at `pre-quarto` in the extension manifest, so listing `lua-env` under `filters` is enough. The shortcode reads metadata the filter publishes, and a filter left at the default entry point published it after Quarto had expanded the shortcodes, so every `{{< lua-env >}}` rendered as nothing unless the entry point was named by hand.
+- fix: Raise `quarto-required` to `>=1.9.38`, the first version whose `_extension.yml` schema accepts a filter entry point.
+
 ## 1.5.1 (2026-08-01)
 
 ### Documentation

--- a/_extensions/lua-env/_extension.yml
+++ b/_extensions/lua-env/_extension.yml
@@ -1,9 +1,10 @@
 title: Lua Environment
 author: Mickaël Canouil
 version: 1.5.1
-quarto-required: ">=1.4.459"
+quarto-required: ">=1.9.38"
 contributes:
   shortcodes:
     - lua-env-shortcode.lua
   filters:
-    - lua-env-filter.lua
+    - path: lua-env-filter.lua
+      at: pre-quarto

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -9,8 +9,7 @@ The filter is enabled in this site's `_quarto.yml`:
 
 ```yaml
 filters:
-  - path: lua-env
-    at: pre-quarto
+  - lua-env
 ```
 
 ## Pandoc

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -39,8 +39,7 @@ The filter has to be enabled before the shortcode has anything to read:
 
 ```yaml
 filters:
-  - path: lua-env
-    at: pre-quarto
+  - lua-env
 ```
 
 Then name a value by its dot-separated path:

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -10,23 +10,10 @@ The shortcode reads metadata the filter collects, so the filter has to run first
 
 ```yaml
 filters:
-  - path: lua-env
-    at: pre-quarto
-```
-
-::: {.callout-caution}
-`at: pre-quarto`, not `at: post-quarto`.
-Quarto expands shortcodes during its own pass, so a filter placed after that pass publishes the metadata too late.
-Every `{{{< lua-env >}}}` then warns that no `lua-env` metadata was found and renders nothing, while the document itself builds as though nothing were wrong.
-:::
-
-Ordering the filter by hand has the same effect, and is what a project already listing `quarto` among its filters will be doing:
-
-```yaml
-filters:
-  - quarto
   - lua-env
 ```
+
+The extension registers the filter at `pre-quarto`, before Quarto expands shortcodes, so the entry point never has to be named here.
 
 ## Shortcode
 

--- a/example.qmd
+++ b/example.qmd
@@ -9,10 +9,7 @@ format:
   html:
     toc: true
 filters:
-  # pre-quarto, not post-quarto: Quarto expands shortcodes during its own pass,
-  # so a filter placed after it publishes the metadata too late.
-  - path: lua-env
-    at: pre-quarto
+  - lua-env
 extensions:
   lua-env:
     json: false


### PR DESCRIPTION
The extension manifest now registers the filter at `pre-quarto`, so listing `lua-env` under `filters` is enough and the entry point no longer has to be repeated in project or document YAML. The documentation and `example.qmd` use the short form throughout.

`quarto-required` moves to >=1.9.38, the first version whose `_extension.yml` schema accepts a filter entry point. Below it the render fails validation.