### PR TITLE
build: fetch the schema validator from a release asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Refactoring
 
 - build: Update the vendored Lua modules to 2.3.0, which includes the `schema-check` fix for an extension whose entry points are in a subdirectory. A module no longer carries a version line in its header, so its checksum changes only when its code changes. (#39)
+- build: Fetch the schema validator from a Quarto Wizard release asset rather than a raw path inside its repository, which a refactor could move without notice. The vendored file is unchanged. (#40)
 
 ## 1.6.0 (2026-09-07)
 

--- a/_extensions/lua-env/_dependencies.yml
+++ b/_extensions/lua-env/_dependencies.yml
@@ -23,8 +23,8 @@ sources:
         runtime: any
   quarto-wizard:
     origin: "https://github.com/mcanouil/quarto-wizard"
-    fetch: "https://raw.githubusercontent.com/mcanouil/quarto-wizard/{version}/packages/schema/src/validation/{file}"
-    version: "3.4.0"
+    fetch: "{origin}/releases/download/{version}/{file}"
+    version: "3.5.0"
     licence: MIT
     files:
       schema.lua:


### PR DESCRIPTION
The `quarto-wizard` source fetched `schema.lua` from a raw path inside the monorepo:

```txt
https://raw.githubusercontent.com/mcanouil/quarto-wizard/{version}/packages/schema/src/validation/{file}
```

That depends on the file staying where it is. A refactor could move it with no release note, and every manifest naming it would break at once. The modules source already fetches release assets, so the two used different contracts for no reason.

It now fetches `{origin}/releases/download/{version}/{file}` at 3.5.0, the first release to carry the validator as an asset.

The vendored file does not change. The asset and the raw path serve identical bytes, checked at both 3.4.0 and 3.5.0, so `schema.lua` and the `sha256` this manifest already recorded are untouched. Only the address and the version differ, which this pull request's diff shows.